### PR TITLE
18: fix exception on api error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,12 @@ COPY README.md .
 COPY blocknative blocknative/
 COPY tests tests/
 COPY setup.py .
+
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
 RUN pip3 install --upgrade autopep8
 RUN python3 setup.py install
+
 ENV PYTHONPATH=.
 RUN python3 -m py_compile blocknative/*.py
 RUN python3 -m unittest discover -s tests -p '*test.py'

--- a/blocknative/utils.py
+++ b/blocknative/utils.py
@@ -39,19 +39,19 @@ def raise_error_on_status(message: dict) -> None:
 
     reason = message['reason'].rstrip().lstrip()
     
-    if reason == ErrorReason.RATE_LIMIT:
+    if reason == ErrorReason.RATE_LIMIT.value:
         raise WebsocketRateLimitError(reason)
-    elif reason == ErrorReason.MESSAGE_TOO_LARGE:
+    elif reason == ErrorReason.MESSAGE_TOO_LARGE.value:
         raise MessageSizeError(reason)
     elif ErrorReason.API_KEY_MISSING.value in reason:
         raise MissingAPIKeyError(reason)
-    elif reason == ErrorReason.API_VERSION:
+    elif reason == ErrorReason.API_VERSION.value:
         raise InvalidAPIVersionError(reason)
     elif ErrorReason.API_KEY_INVALID.value in reason:
         raise InvalidAPIKeyError(reason)
-    elif ErrorReason.EVENT_RATE_LIMIT in reason:
+    elif ErrorReason.EVENT_RATE_LIMIT.value in reason:
         raise EventRateLimitError(reason)
-    elif ErrorReason.SIMULATED_RATE_LIMIT in reason:
+    elif ErrorReason.SIMULATED_RATE_LIMIT.value in reason:
         raise SimulatedEventRateLimitError(reason)
     else:
         raise SDKError(reason)


### PR DESCRIPTION
closes: #18 

Found a bug - raise_error on status method is using the Enum field to do string searches where it should use only the 'value' of the enum, aka a string